### PR TITLE
Decode parser updates after OGN format change, py3 bump

### DIFF
--- a/ogn/es/ogn_decode_parser.py
+++ b/ogn/es/ogn_decode_parser.py
@@ -90,16 +90,16 @@ def main():
 def parseline(line):
 	global ess, args
 
-	fieldsre = re.search("([0-9.]+)MHz:[ ]+([^ ]+)[ ]+[0-9]+:[ ]+(\[.*\])deg[ ]+([0-9]+)m[ ]+([-+]?[0-9.]+)m\/s[ ]+([0-9.]+)m\/s[ ]+([0-9.]+)deg[ ]+([+-]?[0-9.]+)deg\/sec[ ]+([0-9]+)[ ]+([0-9]+)x([0-9]+)m[ ]+([0-9a-z_]+)[ ]+([-+]?[0-9.]+)kHz[ ]+([(0-9.]+)\/([(0-9.]+)dB\/([0-9]+)[ ]+([0-9])e[ ]+([0-9.]+)km[ ]+([0-9.]+)deg[ ]+([-+]+[0-9.]+)deg", line)
+	fieldsre = re.search("([0-9.]+)MHz:[ ]+([^ ]+)[ ]+[0-9]+:[ ]+(\[.*\])deg[ ]+([0-9]+)m[ ]+([-+]?[0-9.]+)m\/s[ ]+([0-9.]+)m\/s[ ]+([0-9.]+)deg[ ]+([+-]?[0-9.]+)deg\/s[ ]+([_0-9]+)[ ]+([0-9]+)x([0-9]+)m[ ]+([0-9a-zA-Z_]+)[ ]+([:0-9a-zA-Z_]+)[ ]+([-+]?[0-9.]+)kHz[ ]+([(0-9.]+)\/([(0-9.]+)dB\/([0-9]+)[ ]+([0-9])e[ ]+([0-9.]+)km[ ]+([0-9.]+)deg[ ]+([-+]+[0-9.]+)deg", line)
 
 	# Forward stdin
 	if not args.no_pass_through:
-		print line.rstrip()
+		print(line.rstrip())
 
 	if not fieldsre:
 		# We skip upload of very common lines with little value
 		if re.match("(APRS ->)|(APRS time)", line):
-			print "** Skipping upload of common APRS line **"
+			print("** Skipping upload of common APRS line **")
 			return
 
 		# All other lines we upload (cpu info etc)
@@ -112,7 +112,7 @@ def parseline(line):
 		for es in ess:
 			es.index(index="enop_rawlog", doc_type="lines", body=json.dumps(data))
 
-		print "** Uploaded raw log line to ES **"
+		print("** Uploaded raw log line to ES **")
 
 		# But you should always return here
 		return
@@ -129,11 +129,11 @@ def parseline(line):
 		data["speed"] = float(fieldsre.group(6))
 		data["heading"] = float(fieldsre.group(7))
 		data["heading_change"] = float(fieldsre.group(8))
-		data["signal_strength0"] = float(fieldsre.group(14))
-		data["signal_strength1"] = float(fieldsre.group(15))
-		data["distance"] = float(fieldsre.group(18))
-		data["bearing"] = float(fieldsre.group(19))
-		data["bearing_change"] = float(fieldsre.group(20))
+		data["signal_strength0"] = float(fieldsre.group(15))
+		data["signal_strength1"] = float(fieldsre.group(16))
+		data["distance"] = float(fieldsre.group(19))
+		data["bearing"] = float(fieldsre.group(20))
+		data["bearing_change"] = float(fieldsre.group(21))
 
 		rightnow = datetime.datetime.now()
 		data["timestamp"] = rightnow.isoformat()
@@ -149,10 +149,10 @@ def parseline(line):
 			for es in ess:
 				es.index(index=timeindex, doc_type=elastic_type, body=json.dumps(data))
 
-		print "** Position data detected, uploading to ES: **", data
+		print("** Position data detected, uploading to ES: **", data)
 
 	except:
-		print "** Something went wrong with ogn_decode_parser: ",sys.exc_info()
+		print("** Something went wrong with ogn_decode_parser: ",sys.exc_info())
 
 
 main()


### PR DESCRIPTION
Requirements: pip3 install elasticsearch===7.17.9

Screenshot of working parse. Also tried --dry-run and --input-file , worked fine for a single log line at least...

![image](https://github.com/algefaen/enop/assets/1118158/47f20b98-5bf0-47b2-9603-dfdc6e00ae0e)
